### PR TITLE
update locations of xml files

### DIFF
--- a/src/cfchecker/cfchecks.py
+++ b/src/cfchecker/cfchecks.py
@@ -67,11 +67,11 @@ from cfchecker import __version__
 
 # point to local cache of URL
 # http://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml
-STANDARDNAME = '/home/h03/support/software/cfchecker_rhel7/etc/cf-standard-name-table.xml'
+STANDARDNAME = '/home/h03/cdds/software/cfchecker_rhel7/etc/cf-standard-name-table.xml'
 
 # point to local cache of URL
 # http://cfconventions.org/Data/area-type-table/current/src/area-type-table.xml'
-AREATYPES = '/home/h03/support/software/cfchecker_rhel7/etc/area-type-table.xml'
+AREATYPES = '/home/h03/cdds/software/cfchecker_rhel7/etc/area-type-table.xml'
 REGIONNAMES = 'http://cfconventions.org/Data/cf-standard-names/docs/standardized-region-names.xml'
 
 #-----------------------------------------------------------


### PR DESCRIPTION
Point at the standard names and area types files in the cdds account rather than support following migration of cfchecker tools